### PR TITLE
NDEV-1037 Implemented split vesting command in vesting-cli (#1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,18 +637,18 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "const_format"
-version = "0.2.23"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0936ffe6d0c8d6a51b3b0a73b2acbe925d786f346cf45bfddc8341d79fb7dc8a"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.22"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.18",
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "spl-governance-addin-vesting"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -4683,6 +4683,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap 2.34.0",
+ "const_format",
  "iso8601-duration",
  "solana-account-decoder",
  "solana-clap-utils",

--- a/addin-vesting/cli/Cargo.toml
+++ b/addin-vesting/cli/Cargo.toml
@@ -5,14 +5,15 @@ authors = ["NeonLabs Maintainers <maintainers@neonlabs.org>"]
 edition = "2018"
 
 [dependencies]
-solana-program = "1.10.16"
-solana-client = "1.10.16"
-solana-sdk = "1.10.16"
+chrono = "0.4.19"
+clap = "2.33.3"
+const_format = "0.2.30"
+iso8601-duration = { git = "https://github.com/rrichardson/iso8601-duration.git", rev = "9e01f51ea253e95e0fba5e4d7ad0c537922931e7"}
 solana-account-decoder = "1.10"
 solana-clap-utils = "1.10.16"
-spl-token = {version = "3.2.0", features = ["no-entrypoint"]}
+solana-client = "1.10.16"
+solana-program = "1.10.16"
+solana-sdk = "1.10.16"
 spl-associated-token-account = {version = "1.0.2", features = ["no-entrypoint"]}
 spl-governance-addin-vesting = { version = "0.2", path = "../program" }
-clap = "2.33.3"
-chrono = "0.4.19"
-iso8601-duration = { git = "https://github.com/rrichardson/iso8601-duration.git", rev = "9e01f51ea253e95e0fba5e4d7ad0c537922931e7"}
+spl-token = {version = "3.2.0", features = ["no-entrypoint"]}

--- a/addin-vesting/cli/src/main.rs
+++ b/addin-vesting/cli/src/main.rs
@@ -2,7 +2,9 @@
 use chrono::{NaiveDateTime, DateTime, Duration};
 use clap::{
     crate_description, crate_name, crate_version, value_t, App, AppSettings, Arg, SubCommand,
+    ArgMatches,
 };
+use const_format::concatcp;
 use solana_clap_utils::{
     input_parsers::{keypair_of, pubkey_of, value_of, values_of},
     input_validators::{is_amount, is_keypair, is_pubkey, is_slot, is_url},
@@ -27,7 +29,10 @@ use spl_associated_token_account::{get_associated_token_address};
 use std::convert::TryInto;
 use spl_governance_addin_vesting::{
     state::{ VestingRecord, VestingSchedule },
-    instruction::{ deposit, deposit_with_realm, withdraw, withdraw_with_realm, change_owner, change_owner_with_realm, create_voter_weight_record, set_vote_percentage_with_realm },
+    instruction::{
+        deposit, deposit_with_realm, withdraw, withdraw_with_realm, change_owner, change_owner_with_realm,
+        create_voter_weight_record, set_vote_percentage_with_realm, split, split_with_realm,
+    },
     voter_weight::get_voter_weight_record_address,
 };
 
@@ -88,7 +93,7 @@ fn command_deposit_svc(
     transaction.sign(&[&payer, &vesting_token_keypair, &source_token_owner], latest_blockhash);
 
     msg!("Vesting addin program id: {:?}", vesting_addin_program_id,);
-    msg!("spl-token program id: {:?}", spl_token::id(),);
+    msg!("SPL Token program id: {:?}", spl_token::id(),);
     msg!("Source token owner pubkey: {:?}", source_token_owner.pubkey(),);
     msg!("Source token pubkey: {:?}", source_token_pubkey,);
     msg!("Vesting owner pubkey: {:?}", vesting_owner_pubkey,);
@@ -169,7 +174,7 @@ fn command_deposit_with_realm_svc(
     transaction.sign(&[&payer, &vesting_token_keypair, &source_token_owner], latest_blockhash);
 
     msg!("Vesting addin program id: {:?}", vesting_addin_program_id,);
-    msg!("spl-token program id: {:?}", spl_token::id(),);
+    msg!("SPL Token program id: {:?}", spl_token::id(),);
     msg!("Source token owner pubkey: {:?}", source_token_owner.pubkey(),);
     msg!("Source token pubkey: {:?}", source_token_pubkey,);
     msg!("Vesting owner pubkey: {:?}", vesting_owner_pubkey,);
@@ -396,6 +401,93 @@ fn command_set_vote_percentage_with_realm(
     rpc_client.send_transaction(&transaction).unwrap();
 }
 
+#[allow(clippy::too_many_arguments)]
+fn command_split(
+    rpc_client: RpcClient,
+    governance_program_id: Pubkey,
+    vesting_addin_program_id: Pubkey,
+    payer: Keypair,
+    vesting_owner: Keypair,
+    vesting_token_pubkey: Pubkey,
+    new_vesting_owner_pubkey: Pubkey,
+    schedules: Vec<VestingSchedule>,
+) {
+    let (vesting_pubkey,_) = Pubkey::find_program_address(&[vesting_token_pubkey.as_ref()], &vesting_addin_program_id);
+
+    let vesting_record_account_data = rpc_client.get_account_data(&vesting_pubkey).unwrap();
+    let vesting_record: VestingRecord = try_from_slice_unchecked(&vesting_record_account_data).unwrap();
+
+    let new_vesting_token_keypair = Keypair::new();
+    let new_vesting_token_pubkey = new_vesting_token_keypair.pubkey();
+
+    let (new_vesting_pubkey, _) = Pubkey::find_program_address(
+        &[new_vesting_token_pubkey.as_ref()],
+        &vesting_addin_program_id,
+    );
+
+    msg!("Vesting addin program id: {:?}", vesting_addin_program_id);
+    msg!("SPL Token program id: {:?}", spl_token::id());
+    msg!("Payer: {:?}", payer.pubkey(),);
+    msg!("New vesting owner pubkey: {:?}", new_vesting_owner_pubkey);
+    msg!("New vesting account pubkey: {:?}", new_vesting_pubkey);
+    msg!("New vesting token pubkey: {:?}", new_vesting_token_pubkey);
+    report_schedules(&schedules);
+
+    let instructions = [
+        system_instruction::create_account(
+            &vesting_owner.pubkey(),
+            &new_vesting_token_pubkey,
+            Rent::default().minimum_balance(spl_token::state::Account::LEN),
+            spl_token::state::Account::LEN as u64,
+            &spl_token::id()
+        ),
+
+        spl_token::instruction::initialize_account(
+            &spl_token::id(),
+            &new_vesting_token_pubkey,
+            &vesting_record.mint,
+            &new_vesting_pubkey,
+        ).unwrap(),
+
+        if let Some(realm_pubkey) = vesting_record.realm {
+            split_with_realm(
+                &vesting_addin_program_id,
+                &spl_token::id(),
+                &vesting_token_pubkey,
+                &vesting_owner.pubkey(),
+                &new_vesting_token_pubkey,
+                &new_vesting_owner_pubkey,
+                &payer.pubkey(),
+                schedules,
+                &governance_program_id,
+                &realm_pubkey,
+                &vesting_record.mint,
+            )
+        } else {
+            split(
+                &vesting_addin_program_id,
+                &spl_token::id(),
+                &vesting_token_pubkey,
+                &vesting_owner.pubkey(),
+                &new_vesting_token_pubkey,
+                &new_vesting_owner_pubkey,
+                &payer.pubkey(),
+                schedules,
+            )
+        }.unwrap(),
+    ];
+
+    let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
+
+    let latest_blockhash = rpc_client.get_latest_blockhash().unwrap();
+    transaction.sign(
+        &[&payer, &vesting_owner, &new_vesting_token_keypair],
+        latest_blockhash,
+    );
+
+    rpc_client.send_transaction(&transaction).unwrap();
+}
+
 fn command_info(
     rpc_client: RpcClient,
     vesting_addin_program_id: Pubkey,
@@ -420,126 +512,215 @@ fn report_vesting_record_info(vesting_record: &VestingRecord) {
     msg!("Vesting Token Address: {:?}", &vesting_record.token);
     msg!("Vesting Realm: {:?}", &vesting_record.realm);
 
-    let schedules = &vesting_record.schedule;
+    report_schedules(&vesting_record.schedule);
+}
 
+fn report_schedules(schedules: &[VestingSchedule]) {
     msg!("Schedule:");
-    for (i, item) in schedules.iter().enumerate() {
-        msg!("  {:2}: amount {}, timestamp {} ({})",
+    let total_amount: u64 = schedules.iter()
+        .enumerate()
+        .map(|(i, item)| {
+            msg!("  {:2}: amount {}, timestamp {} ({})",
                 i,
                 &item.amount,
                 &item.release_time,
                 NaiveDateTime::from_timestamp(item.release_time.try_into().unwrap(), 0u32),
             );
-    }
-    msg!("Total amount: {}", schedules.iter().map(|v| v.amount).sum::<u64>());
+            item.amount
+        }).sum();
+    msg!("Total amount: {}", total_amount);
 }
 
-fn main() {
-    let matches = App::new(crate_name!())
-        .about(crate_description!())
-        .version(crate_version!())
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .arg(
-            Arg::with_name("verbose")
-                .long("verbose")
-                .short("v")
-                .takes_value(false)
-                .global(true)
-                .help("Show additional information"),
+fn parse_schedules(arg_matches: &ArgMatches) -> Vec<VestingSchedule> {
+    let mut schedule_amounts: Vec<u64> = values_of(arg_matches, "amounts").unwrap();
+    let release_frequency: Option<String> = value_of(arg_matches, "release-frequency");
+    let schedule_times = if let Some(release_frequency_some) = release_frequency {
+        // best found in rust
+        let release_frequency: iso8601_duration::Duration =
+            release_frequency_some.parse().unwrap();
+        let release_frequency: u64 = Duration::from_std(release_frequency.to_std())
+            .unwrap()
+            .num_seconds()
+            .try_into()
+            .unwrap();
+        if schedule_amounts.len() > 1 {
+            panic!("Linear vesting must have one amount which will split into parts per period")
+        }
+        let start: u64 = DateTime::parse_from_rfc3339(
+            &value_of::<String>(arg_matches, "start-date-time").unwrap(),
         )
-        .arg(
-            Arg::with_name("rpc_url")
-                .long("url")
-                .value_name("URL")
-                .default_value("http://localhost:8899")
-                .validator(is_url)
-                .takes_value(true)
-                .global(true)
-                .help(
-                    "Specify the url of the rpc client (solana network).",
-                ),
+            .unwrap()
+            .timestamp()
+            .try_into()
+            .unwrap();
+        let end: u64 = DateTime::parse_from_rfc3339(
+            &value_of::<String>(arg_matches, "end-date-time").unwrap(),
         )
-        .arg(
-            Arg::with_name("governance_program_id")
-                .long("governance_program_id")
+            .unwrap()
+            .timestamp()
+            .try_into()
+            .unwrap();
+        let total = schedule_amounts[0];
+        let part = (((total as u128) * (release_frequency as u128)) / ((end - start) as u128))
+            .try_into()
+            .unwrap();
+        schedule_amounts.clear();
+        let mut linear_vesting = Vec::new();
+
+        let q = total / part;
+        let r = total % part;
+
+        for n in 0..q {
+            linear_vesting.push(start + n * release_frequency);
+            schedule_amounts.push(part);
+        }
+
+        if r != 0 {
+            schedule_amounts[(q - 1) as usize] += r;
+        }
+
+        if linear_vesting.len() > 365 {
+            panic!("Total count of vesting periods is more than 365. Not sure if you want to do that.")
+        }
+
+        assert_eq!(schedule_amounts.iter().sum::<u64>(), total);
+
+        linear_vesting
+    } else {
+        values_of(arg_matches, "release-times")
+            .expect("No `release-frequency` nor `release-times` was set")
+    };
+
+    if schedule_amounts.len() != schedule_times.len() {
+        eprintln!("error: Number of amounts given is not equal to number of release heights given.");
+        std::process::exit(1);
+    }
+    let mut schedules = Vec::with_capacity(schedule_amounts.len());
+    for (&a, &h) in schedule_amounts.iter().zip(schedule_times.iter()) {
+        schedules.push(VestingSchedule {
+            release_time: h,
+            amount: a,
+        });
+    }
+
+    schedules
+}
+
+const PAYER_HELP: &str = "Specify the transaction fee payer account address. \
+                          This may be a keypair file, the ASK keyword.";
+
+fn payer_arg<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name("payer")
+        .long("payer")
+        .value_name("KEYPAIR")
+        .validator(is_keypair)
+        .takes_value(true)
+}
+
+/// Implements repetitive arguments in order to reduce boilerplate
+trait ArgsHelper {
+    fn arg_optional_payer(self) -> Self;
+    fn arg_payer(self) -> Self;
+    fn arg_vesting_address(self) -> Self;
+    fn arg_vesting_owner_keypair(self) -> Self;
+    fn arg_vesting_owner_address(self, required: bool) -> Self;
+    fn arg_new_vesting_owner(self) -> Self;
+    fn arg_realm_address(self, required: bool) -> Self;
+    fn arg_mint_address(self, required: bool) -> Self;
+    fn arg_schedules(self) -> Self;
+}
+
+impl ArgsHelper for App<'_, '_> {
+    fn arg_optional_payer(self) -> Self {
+        self.arg(payer_arg().help(PAYER_HELP))
+    }
+
+    fn arg_payer(self) -> Self {
+        self.arg(
+            payer_arg()
+                .required(true)
+                .help(concatcp!(PAYER_HELP, " Defaults to the client keypair."))
+        )
+    }
+
+    fn arg_vesting_address(self) -> Self {
+        self.arg(
+            Arg::with_name("vesting_address")
+                .long("vesting_address")
                 .value_name("ADDRESS")
-                .default_value("82pQHEmBbW6CQS8GzLP3WE2pCgMUPSW2XzpuSih3aFDk")
+                .required(true)
                 .validator(is_pubkey)
                 .takes_value(true)
-                .global(true)
+                .help("Specify the vesting token address (publickey)."),
+        )
+    }
+
+    fn arg_vesting_owner_keypair(self) -> Self {
+        self.arg(
+            Arg::with_name("vesting_owner")
+                .long("vesting_owner")
+                .value_name("KEYPAIR")
+                .required(true)
+                .validator(is_keypair)
+                .takes_value(true)
                 .help(
-                    "Specify the address (public key) of the governance program.",
+                    "Specify the vesting owner account address. \
+                        This may be a keypair file, the ASK keyword.",
                 ),
         )
-        .arg(
-            Arg::with_name("vesting_program_id")
-                .long("vesting_program_id")
+    }
+
+    fn arg_vesting_owner_address(self, required: bool) -> Self {
+        self.arg(
+            Arg::with_name("vesting_owner")
+                .long("vesting_owner")
                 .value_name("ADDRESS")
-                .default_value("Hu548Kzvfo9C9zATuXVpnmxYRUCJxrsXLdiKjxuTczim")
+                .required(required)
                 .validator(is_pubkey)
                 .takes_value(true)
-                .global(true)
-                .help(
-                    "Specify the address (public key) of the vesting addin program.",
-                ),
+                .help("Specify the address (publickey) of the vesting record owner."),
         )
-        .subcommand(SubCommand::with_name("deposit").about("Create a new vesting contract with an optional release schedule")        
-            .arg(
-                Arg::with_name("source_owner")
-                    .long("source_owner")
-                    .value_name("KEYPAIR")
-                    .required(true)
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the source account owner. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("source_token_address")
-                    .long("source_token_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the source token account address.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_owner")
-                    .long("vesting_owner")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the vesting record owner.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("mint_address")
-                    .long("mint_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the mint for the token that should be used.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("realm_address")
-                    .long("realm_address")
-                    .value_name("ADDRESS")
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the governance realm.",
-                    ),
-            )
+    }
+
+    fn arg_new_vesting_owner(self) -> Self {
+        self.arg(
+            Arg::with_name("new_vesting_owner")
+                .long("new_vesting_owner")
+                .value_name("ADDRESS")
+                .required(true)
+                .validator(is_pubkey)
+                .takes_value(true)
+                .help("Specify the new vesting owner address (publickey)."),
+        )
+    }
+
+    fn arg_realm_address(self, required: bool) -> Self {
+        self.arg(
+            Arg::with_name("realm_address")
+                .long("realm_address")
+                .value_name("ADDRESS")
+                .required(required)
+                .validator(is_pubkey)
+                .takes_value(true)
+                .help("Specify the address (publickey) of the governance realm."),
+        )
+    }
+
+    fn arg_mint_address(self, required: bool) -> Self {
+        self.arg(
+            Arg::with_name("mint_address")
+                .long("mint_address")
+                .value_name("ADDRESS")
+                .required(required)
+                .validator(is_pubkey)
+                .takes_value(true)
+                .help("Specify the address (publickey) of the mint for the token that should be used."),
+        )
+    }
+
+    fn arg_schedules(self) -> Self {
+        self
+            // scheduled vesting
             .arg(
                 Arg::with_name("amounts")
                     .long("amounts")
@@ -553,29 +734,28 @@ fn main() {
                     .allow_hyphen_values(true)
                     .help(
                         "Amounts of tokens to transfer via the vesting \
-                        contract. Multiple inputs separated by a comma are
-                        accepted for the creation of multiple schedules. The sequence of inputs \
-                        needs to end with an exclamation mark ( e.g. 1,2,3,! )",
+                            contract. Multiple inputs separated by a comma are
+                            accepted for the creation of multiple schedules. The sequence of inputs \
+                            needs to end with an exclamation mark ( e.g. 1,2,3,! )",
                     ),
             )
-            // scheduled vesting
             .arg(
-                Arg::with_name("release-times")
-                    .long("release-times")
-                    .conflicts_with("release-frequency")
-                    .value_name("SLOT")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .use_delimiter(true)
-                    .value_terminator("!")
-                    .allow_hyphen_values(true)
-                    .help(
-                        "Release times in unix timestamp to decide when the contract is \
+            Arg::with_name("release-times")
+                .long("release-times")
+                .conflicts_with("release-frequency")
+                .value_name("SLOT")
+                .validator(is_slot)
+                .takes_value(true)
+                .multiple(true)
+                .use_delimiter(true)
+                .value_terminator("!")
+                .allow_hyphen_values(true)
+                .help(
+                    "Release times in unix timestamp to decide when the contract is \
                         unlockable. Multiple inputs separated by a comma are
                         accepted for the creation of multiple schedules. The sequence of inputs \
                         needs to end with an exclamation mark ( e.g. 1,2,3,! ).",
-                    ),
+                ),
             )
             // linear vesting
             .arg(
@@ -583,7 +763,7 @@ fn main() {
                     .long("release-frequency")
                     .value_name("RELEASE_FREQUENCY")
                     .takes_value(true)
-                    .conflicts_with("release-times")                                        
+                    .conflicts_with("release-times")
                     .help(
                         "Frequency of release amount. \
                         You start on 1sth of Nov and end on 5th of Nov. \
@@ -612,277 +792,185 @@ fn main() {
                     .help(
                         "Last time of release in linear vesting. \
                         If frequency will go over last release time, \
-                        tokens will be released later than end date. 
+                        tokens will be released later than end date.
                         Must be RFC 3339 and ISO 8601 sortable date time. \
                         Example, 2022-17-06T20:11:18Z",
                     ),
             )
-            .arg(
-                Arg::with_name("payer")
-                    .long("payer")
-                    .value_name("KEYPAIR")
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the transaction fee payer account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("confirm")
-                    .long("confirm")
-                    .value_name("CONFIRM")
-                    .takes_value(true)
-                    .default_value("true")
-                    .help(
-                        "Specify whether to wait transaction confirmation"
-                    ),
-            )
+    }
+}
+
+fn main() {
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .arg(
+            Arg::with_name("verbose")
+                .long("verbose")
+                .short("v")
+                .takes_value(false)
+                .global(true)
+                .help("Show additional information"),
         )
-        .subcommand(SubCommand::with_name("withdraw").about("Unlock & Withdraw a vesting contract. This will only release \
-        the schedules that have reached maturity.")
-            .arg(
-                Arg::with_name("payer")
-                    .long("payer")
-                    .value_name("KEYPAIR")
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the transaction fee payer account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_owner")
-                    .long("vesting_owner")
-                    .value_name("KEYPAIR")
-                    .required(true)
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting owner account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_address")
-                    .long("vesting_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting token address (publickey).",
-                    ),
-            )
-            .arg(
-                Arg::with_name("destination_address")
-                    .long("destination_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the destination token address (publickey).",
-                    ),
-            )
+        .arg(
+            Arg::with_name("rpc_url")
+                .long("url")
+                .value_name("URL")
+                .default_value("http://localhost:8899")
+                .validator(is_url)
+                .takes_value(true)
+                .global(true)
+                .help("Specify the url of the rpc client (solana network)."),
         )
-        .subcommand(SubCommand::with_name("change-owner").about("Change the owner of a vesting contract")
-            .arg(
-                Arg::with_name("payer")
-                    .long("payer")
-                    .value_name("KEYPAIR")
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the transaction fee payer account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_owner")
-                    .long("vesting_owner")
-                    .value_name("KEYPAIR")
-                    .required(true)
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting owner account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_address")
-                    .long("vesting_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting token address (publickey).",
-                    ),
-            )
-            .arg(
-                Arg::with_name("new_vesting_owner")
-                    .long("new_vesting_owner")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the new vesting owner address (publickey).",
-                    ),
-            )
+        .arg(
+            Arg::with_name("governance_program_id")
+                .long("governance_program_id")
+                .value_name("ADDRESS")
+                .default_value("82pQHEmBbW6CQS8GzLP3WE2pCgMUPSW2XzpuSih3aFDk")
+                .validator(is_pubkey)
+                .takes_value(true)
+                .global(true)
+                .help("Specify the address (public key) of the governance program."),
         )
-        .subcommand(SubCommand::with_name("create-voter-weight-record").about("Create Voter Weight Record")
-            .arg(
-                Arg::with_name("payer")
-                    .long("payer")
-                    .value_name("KEYPAIR")
-                    .required(true)
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the transaction fee payer account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("record_owner")
-                    .long("record_owner")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the record owner address (publickey).",
-                    ),
-            )
-            .arg(
-                Arg::with_name("mint_address")
-                    .long("mint_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the mint for the token that should be used.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("realm_address")
-                    .long("realm_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the governance realm.",
-                    ),
-            )
+        .arg(
+            Arg::with_name("vesting_program_id")
+                .long("vesting_program_id")
+                .value_name("ADDRESS")
+                .default_value("Hu548Kzvfo9C9zATuXVpnmxYRUCJxrsXLdiKjxuTczim")
+                .validator(is_pubkey)
+                .takes_value(true)
+                .global(true)
+                .help("Specify the address (public key) of the vesting addin program."),
         )
-        .subcommand(SubCommand::with_name("set-vote-percentage").about("Set vote percentage of a vesting contract for a Realm")
-            .arg(
-                Arg::with_name("payer")
-                    .long("payer")
-                    .value_name("KEYPAIR")
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the transaction fee payer account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_authority")
-                    .long("vesting_authority")
-                    .value_name("KEYPAIR")
-                    .required(true)
-                    .validator(is_keypair)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting authority account address. \
-                        This may be a keypair file, the ASK keyword. \
-                        Defaults to the client keypair.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("vesting_owner")
-                    .long("vesting_owner")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting owner address (publickey).",
-                    ),
-            )
-            .arg(
-                Arg::with_name("mint_address")
-                    .long("mint_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the mint for the token that should be used.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("realm_address")
-                    .long("realm_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the address (publickey) of the governance realm.",
-                    ),
-            )
-            .arg(
-                Arg::with_name("percentage")
-                    .long("percentage")
-                    .value_name("PERCENTAGE")
-                    .required(true)
-                    .validator(is_amount)
-                    .takes_value(true)
-                    .help(
-                        "Deposited tokens percentage of voting.",
-                    ),
-            )
+        .subcommand(
+            SubCommand::with_name("deposit")
+                .about("Create a new vesting contract with an optional release schedule")
+                .arg(
+                    Arg::with_name("source_owner")
+                        .long("source_owner")
+                        .value_name("KEYPAIR")
+                        .required(true)
+                        .validator(is_keypair)
+                        .takes_value(true)
+                        .help(
+                            "Specify the source account owner. \
+                            This may be a keypair file, the ASK keyword. \
+                            Defaults to the client keypair.",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("source_token_address")
+                        .long("source_token_address")
+                        .value_name("ADDRESS")
+                        .required(true)
+                        .validator(is_pubkey)
+                        .takes_value(true)
+                        .help("Specify the source token account address."),
+                )
+                .arg_vesting_owner_address(true)
+                .arg_mint_address(true)
+                .arg_realm_address(true)
+                .arg_schedules()
+                .arg_optional_payer()
+                .arg(
+                    Arg::with_name("confirm")
+                        .long("confirm")
+                        .value_name("CONFIRM")
+                        .takes_value(true)
+                        .default_value("true")
+                        .help("Specify whether to wait transaction confirmation"),
+                )
         )
-        .subcommand(SubCommand::with_name("info").about("Print information about a vesting contract")
-            .arg(
-                Arg::with_name("vesting_address")
-                    .long("vesting_address")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting token address (publickey).",
-                    ),
-            )
+        .subcommand(
+            SubCommand::with_name("withdraw")
+                .about("Unlock & Withdraw a vesting contract. This will only release \
+                        the schedules that have reached maturity.")
+                .arg_optional_payer()
+                .arg_vesting_owner_keypair()
+                .arg_vesting_address()
+                .arg(
+                    Arg::with_name("destination_address")
+                        .long("destination_address")
+                        .value_name("ADDRESS")
+                        .required(true)
+                        .validator(is_pubkey)
+                        .takes_value(true)
+                        .help("Specify the destination token address (publickey)."),
+                )
         )
-        .subcommand(SubCommand::with_name("info-owner").about("Print information about vesting contracts of a vesting owner")
-            .arg(
-                Arg::with_name("vesting_owner")
-                    .long("vesting_owner")
-                    .value_name("ADDRESS")
-                    .required(true)
-                    .validator(is_pubkey)
-                    .takes_value(true)
-                    .help(
-                        "Specify the vesting owner address (publickey).",
-                    ),
-            )
+        .subcommand(
+            SubCommand::with_name("change-owner")
+                .about("Change the owner of a vesting contract")
+                .arg_optional_payer()
+                .arg_vesting_owner_keypair()
+                .arg_vesting_address()
+                .arg_new_vesting_owner()
+        )
+        .subcommand(
+            SubCommand::with_name("create-voter-weight-record")
+                .about("Create Voter Weight Record")
+                .arg_payer()
+                .arg(
+                    Arg::with_name("record_owner")
+                        .long("record_owner")
+                        .value_name("ADDRESS")
+                        .required(true)
+                        .validator(is_pubkey)
+                        .takes_value(true)
+                        .help("Specify the record owner address (publickey)."),
+                )
+                .arg_mint_address(true)
+                .arg_realm_address(true)
+        )
+        .subcommand(
+            SubCommand::with_name("set-vote-percentage")
+                .about("Set vote percentage of a vesting contract for a Realm")
+                .arg_optional_payer()
+                .arg(
+                    Arg::with_name("vesting_authority")
+                        .long("vesting_authority")
+                        .value_name("KEYPAIR")
+                        .required(true)
+                        .validator(is_keypair)
+                        .takes_value(true)
+                        .help(
+                            "Specify the vesting authority account address. \
+                            This may be a keypair file, the ASK keyword. \
+                            Defaults to the client keypair.",
+                        ),
+                )
+                .arg_vesting_owner_address(true)
+                .arg_mint_address(true)
+                .arg_realm_address(true)
+                .arg(
+                    Arg::with_name("percentage")
+                        .long("percentage")
+                        .value_name("PERCENTAGE")
+                        .required(true)
+                        .validator(is_amount)
+                        .takes_value(true)
+                        .help("Deposited tokens percentage of voting."),
+                )
+        )
+        .subcommand(
+            SubCommand::with_name("split")
+                .about("Move remaining vesting to another account using a new release schedule")
+                .arg_optional_payer()
+                .arg_vesting_owner_keypair()
+                .arg_vesting_address()
+                .arg_new_vesting_owner()
+                .arg_schedules()
+        )
+        .subcommand(
+            SubCommand::with_name("info")
+                .about("Print information about a vesting contract")
+                .arg_vesting_address()
+        )
+        .subcommand(
+            SubCommand::with_name("info-owner")
+                .about("Print information about vesting contracts of a vesting owner")
+                .arg_vesting_owner_address(true)
         )
         .get_matches();
 
@@ -902,80 +990,8 @@ fn main() {
             let realm_opt: Option<Pubkey> = pubkey_of(arg_matches, "realm_address");
 
             let payer_keypair = keypair_of(arg_matches, "payer").unwrap_or_else(|| keypair_of(arg_matches, "source_owner").unwrap() );
-
-            // Parsing schedules
-            let mut schedule_amounts: Vec<u64> = values_of(arg_matches, "amounts").unwrap();
             let confirm: bool = value_of(arg_matches, "confirm").unwrap();
-            let release_frequency: Option<String> = value_of(arg_matches, "release-frequency");
-
-            let schedule_times = if let Some(release_frequency_some) = release_frequency {
-                // best found in rust
-                let release_frequency: iso8601_duration::Duration =
-                    release_frequency_some.parse().unwrap();
-                let release_frequency: u64 = Duration::from_std(release_frequency.to_std())
-                    .unwrap()
-                    .num_seconds()
-                    .try_into()
-                    .unwrap();
-                if schedule_amounts.len() > 1 {
-                    panic!("Linear vesting must have one amount which will split into parts per period")
-                }
-                let start: u64 = DateTime::parse_from_rfc3339(
-                    &value_of::<String>(arg_matches, "start-date-time").unwrap(),
-                )
-                .unwrap()
-                .timestamp()
-                .try_into()
-                .unwrap();
-                let end: u64 = DateTime::parse_from_rfc3339(
-                    &value_of::<String>(arg_matches, "end-date-time").unwrap(),
-                )
-                .unwrap()
-                .timestamp()
-                .try_into()
-                .unwrap();
-                let total = schedule_amounts[0];
-                let part = (((total as u128) * (release_frequency as u128))
-                    / ((end - start) as u128))
-                    .try_into()
-                    .unwrap();
-                schedule_amounts.clear();
-                let mut linear_vesting = Vec::new();
-
-                let q = total / part;
-                let r = total % part;
-
-                for n in 0..q {
-                    linear_vesting.push(start + n * release_frequency);
-                    schedule_amounts.push(part);
-                }
-
-                if r != 0 {
-                    schedule_amounts[(q - 1) as usize] += r;
-                }
-
-                if linear_vesting.len() > 365 {
-                    panic!("Total count of vesting periods is more than 365. Not sure if you want to do that.")
-                }
-
-                assert_eq!(schedule_amounts.iter().sum::<u64>(), total);
-
-                linear_vesting
-            } else {
-                values_of(arg_matches, "release-times").unwrap()
-            };
-
-            if schedule_amounts.len() != schedule_times.len() {
-                eprintln!("error: Number of amounts given is not equal to number of release heights given.");
-                std::process::exit(1);
-            }
-            let mut schedules: Vec<VestingSchedule> = Vec::with_capacity(schedule_amounts.len());
-            for (&a, &h) in schedule_amounts.iter().zip(schedule_times.iter()) {
-                schedules.push(VestingSchedule {
-                    release_time: h,
-                    amount: a,
-                });
-            }
+            let schedules = parse_schedules(arg_matches);
 
             if let Some(realm_pubkey) = realm_opt {
                 command_deposit_with_realm_svc(
@@ -1125,6 +1141,24 @@ fn main() {
                 percentage,
             )
         }
+        ("split", Some(arg_matches)) => {
+            let payer_keypair = keypair_of(arg_matches, "payer").unwrap_or_else(|| keypair_of(arg_matches, "vesting_owner").unwrap() );
+            let vesting_owner_keypair = keypair_of(arg_matches, "vesting_owner").unwrap();
+            let vesting_token_pubkey = pubkey_of(arg_matches, "vesting_address").unwrap();
+            let new_vesting_owner_pubkey = pubkey_of(arg_matches, "new_vesting_owner").unwrap();
+            let schedules = parse_schedules(arg_matches);
+
+            command_split(
+                rpc_client,
+                governance_program_id,
+                vesting_addin_program_id,
+                payer_keypair,
+                vesting_owner_keypair,
+                vesting_token_pubkey,
+                new_vesting_owner_pubkey,
+                schedules,
+            )
+        }
         ("info", Some(arg_matches)) => {
             let vesting_token_pubkey = pubkey_of(arg_matches, "vesting_address").unwrap();
             command_info(rpc_client, vesting_addin_program_id, vesting_token_pubkey)
@@ -1138,6 +1172,7 @@ fn main() {
                     RpcProgramAccountsConfig {
                         filters: Some(vec![
                             rpc_filter::RpcFilterType::Memcmp(
+                                #[allow(deprecated)]
                                 rpc_filter::Memcmp {
                                     offset: 0,
                                     bytes: rpc_filter::MemcmpEncodedBytes::Bytes({


### PR DESCRIPTION
* Fixed clippy warnings

* Simplified `verify_schedule` implementation

* Revert "Simplified `verify_schedule` implementation"

This reverts commit 4bab3c65f0d16e578ceaf853b83fa0c2f1fa2dda.

* Implemented `split` command

* Reverted changes in Solana programs